### PR TITLE
Links should always be present

### DIFF
--- a/src/PPWCode.Server.Core/Managers/Implementations/LinksManager.cs
+++ b/src/PPWCode.Server.Core/Managers/Implementations/LinksManager.cs
@@ -49,6 +49,11 @@ namespace PPWCode.Server.Core.Managers.Implementations
                 return;
             }
 
+            if (dto.Links == null)
+            {
+                dto.Links = new Dictionary<string, IDictionary<string, object>>();
+            }
+
             Uri href = GetHref(source, context);
             if (href != null)
             {

--- a/src/PPWCode.Server.Core/Managers/Implementations/LinksManager.cs
+++ b/src/PPWCode.Server.Core/Managers/Implementations/LinksManager.cs
@@ -57,7 +57,7 @@ namespace PPWCode.Server.Core.Managers.Implementations
             Uri href = GetHref(source, context);
             if (href != null)
             {
-                AddLink(dto, SelfKey, new Dictionary<string, object> { { HRefKey, href } });
+                dto.Links.TryAdd(SelfKey, new Dictionary<string, object> { { HRefKey, href } });
                 dto.HRef = href;
             }
 
@@ -65,7 +65,7 @@ namespace PPWCode.Server.Core.Managers.Implementations
                 GetAdditionalLinks(source, context)
                     .Where(kv => !string.IsNullOrWhiteSpace(kv.Key) && (kv.Value != null)))
             {
-                AddLink(dto, additionalLink.Key, additionalLink.Value);
+                dto.Links.TryAdd(additionalLink.Key, additionalLink.Value);
             }
         }
 

--- a/src/PPWCode.Server.Core/Managers/Implementations/LinksManager.cs
+++ b/src/PPWCode.Server.Core/Managers/Implementations/LinksManager.cs
@@ -159,34 +159,6 @@ namespace PPWCode.Server.Core.Managers.Implementations
         }
 
         /// <summary>
-        ///     Add a new link to <see cref="ILinksDto.Links" />.
-        /// </summary>
-        /// <param name="dto">Dto that contains a member <see cref="ILinksDto.Links" /></param>
-        /// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
-        /// <param name="key">Key of the link</param>
-        /// <param name="href">Link itself</param>
-        /// <remarks>A key can be added, if the key is not already exists as link and the reference is not null.</remarks>
-        /// <result>If they is added, it will return true.</result>
-        protected virtual bool AddLink(
-            [NotNull] TLinksDto dto,
-            [NotNull] string key,
-            [NotNull] IDictionary<string, object> value)
-        {
-            if ((dto.Links == null) || !dto.Links.ContainsKey(key))
-            {
-                if (dto.Links == null)
-                {
-                    dto.Links = new Dictionary<string, IDictionary<string, object>>();
-                }
-
-                dto.Links.Add(key, value);
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
         ///     The possibility to enrich the <see cref="ILinksDto.Links" /> list.
         /// </summary>
         /// <param name="source">The source where we extract our information</param>


### PR DESCRIPTION
Change to the LinksManager so that the HATEOAS _link is always initialized and thus always present in the response regardless of containing any actual links.